### PR TITLE
Enhance server-side & client-side form validation

### DIFF
--- a/DynamoLeagueBlazor/Client/DynamoLeagueBlazor.Client.csproj
+++ b/DynamoLeagueBlazor/Client/DynamoLeagueBlazor.Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazored.FluentValidation" Version="2.0.3" />
+    <PackageReference Include="Blazored.FluentValidation" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="6.0.0" />

--- a/DynamoLeagueBlazor/Client/Features/FreeAgents/Detail.razor
+++ b/DynamoLeagueBlazor/Client/Features/FreeAgents/Detail.razor
@@ -21,10 +21,6 @@ else
         @_title
     </Title>
 
-    <MudText Align=Align.Center Typo=Typo.h3>
-        @_title
-    </MudText>
-
     <MudCard>
         <MudCardContent>
             <MudGrid>
@@ -41,9 +37,9 @@ else
                 <MudItem md=9 xs=12>
                     <MudText Typo=Typo.h6>Submit A New Bid</MudText>
                     <EditForm Model=_form OnValidSubmit=OnValidSubmitAsync>
-                        <FluentValidationValidator />
+                        <FluentValidationValidator Validator=_validator/>
                         <MudNumericField @bind-Value="_form.Amount" Label="Bid Amount" Variant="Variant.Text" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.AttachMoney" HideSpinButtons="true" Class="mb-2" For="@(() => _form.Amount)"/>
-                        <MudButton Color="Color.Success" Variant=Variant.Outlined StartIcon=@Icons.Outlined.Check OnClick="OnValidSubmitAsync" Disabled="@_processingForm">
+                        <MudButton Color="Color.Success" Variant=Variant.Outlined StartIcon=@Icons.Outlined.Check ButtonType=ButtonType.Submit Disabled="@_processingForm" FullWidth=true>
                             @if (_processingForm)
                             {
                                 <MudProgressCircular Class="ms-n1" Size="Size.Small" Indeterminate="true"/>

--- a/DynamoLeagueBlazor/Client/Features/FreeAgents/Detail.razor.cs
+++ b/DynamoLeagueBlazor/Client/Features/FreeAgents/Detail.razor.cs
@@ -89,12 +89,21 @@ public class BidAmountValidator : IBidAmountValidator
 
     public async Task<bool> IsHighestBidAsync(AddBidRequest request, CancellationToken cancellationToken)
     {
+        var uri = AddBidRouteFactory.CreateRequestUri(request);
+        return await _httpClient.GetFromJsonAsync<bool>(uri, cancellationToken);
+    }
+}
+
+public static class AddBidRouteFactory
+{
+    public static string CreateRequestUri(AddBidRequest request)
+    {
         var uri = QueryHelpers.AddQueryString("freeagents/addbid", new Dictionary<string, string>
         {
             { nameof(AddBidRequest.PlayerId), request.PlayerId.ToString() },
             { nameof(AddBidRequest.Amount), request.Amount.ToString() }
         });
 
-        return await _httpClient.GetFromJsonAsync<bool>(uri, cancellationToken);
+        return uri;
     }
 }

--- a/DynamoLeagueBlazor/Client/Features/FreeAgents/Detail.razor.cs
+++ b/DynamoLeagueBlazor/Client/Features/FreeAgents/Detail.razor.cs
@@ -13,8 +13,7 @@ public partial class Detail : IDisposable
 {
     [Inject] private HttpClient HttpClient { get; set; } = null!;
     [Inject] private ISnackbar SnackBar { get; set; } = null!;
-    [Inject]
-    private IBidAmountValidator BidAmountValidator { get; set; } = null!;
+    [Inject] private IBidAmountValidator BidAmountValidator { get; set; } = null!;
     [Parameter] public int PlayerId { get; set; }
 
     private FreeAgentDetailResult? _result;

--- a/DynamoLeagueBlazor/Client/Program.cs
+++ b/DynamoLeagueBlazor/Client/Program.cs
@@ -1,5 +1,7 @@
 using DynamoLeagueBlazor.Client;
 using DynamoLeagueBlazor.Client.Areas.Identity;
+using DynamoLeagueBlazor.Client.Features.FreeAgents;
+using DynamoLeagueBlazor.Shared.Features.FreeAgents;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
@@ -28,6 +30,8 @@ try
     {
         config.SnackbarConfiguration.PositionClass = Defaults.Classes.Position.BottomCenter;
     });
+
+    builder.Services.AddTransient<IBidAmountValidator, BidAmountValidator>();
 
     var host = builder.Build();
 

--- a/DynamoLeagueBlazor/Client/wwwroot/manifest.json
+++ b/DynamoLeagueBlazor/Client/wwwroot/manifest.json
@@ -13,9 +13,9 @@
       "sizes": "512x512"
     },
     {
-      "src": "icon-128.png",
+      "src": "icon-192.png",
       "type": "image/png",
-      "sizes": "128x128"
+      "sizes": "192x192"
     }
   ]
 }

--- a/DynamoLeagueBlazor/Server/Features/Admin/SeasonStatus.cs
+++ b/DynamoLeagueBlazor/Server/Features/Admin/SeasonStatus.cs
@@ -20,9 +20,9 @@ public class SeasonStatusController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<bool> GetAsync()
+    public async Task<bool> GetAsync(CancellationToken cancellationToken)
     {
-        return await _mediator.Send(new SeasonStatusQuery());
+        return await _mediator.Send(new SeasonStatusQuery(), cancellationToken);
     }
 }
 

--- a/DynamoLeagueBlazor/Server/Features/Admin/StartSeason.cs
+++ b/DynamoLeagueBlazor/Server/Features/Admin/StartSeason.cs
@@ -21,9 +21,9 @@ public class StartSeasonController : ControllerBase
     }
 
     [HttpPost]
-    public async Task<IActionResult> PostAsync()
+    public async Task<IActionResult> PostAsync(CancellationToken cancellationToken)
     {
-        await _mediator.Send(new StartSeasonQuery());
+        await _mediator.Send(new StartSeasonQuery(), cancellationToken);
 
         return NoContent();
     }

--- a/DynamoLeagueBlazor/Server/Features/Dashboard/TopOffenders.cs
+++ b/DynamoLeagueBlazor/Server/Features/Dashboard/TopOffenders.cs
@@ -23,9 +23,9 @@ public class TopOffendersController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<TopOffendersResult> GetAsync()
+    public async Task<TopOffendersResult> GetAsync(CancellationToken cancellationToken)
     {
-        return await _mediator.Send(new TopOffendersQuery());
+        return await _mediator.Send(new TopOffendersQuery(), cancellationToken);
     }
 }
 

--- a/DynamoLeagueBlazor/Server/Features/Fines/List.cs
+++ b/DynamoLeagueBlazor/Server/Features/Fines/List.cs
@@ -23,9 +23,9 @@ public class ListController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<FineListResult> GetAsync()
+    public async Task<FineListResult> GetAsync(CancellationToken cancellationToken)
     {
-        return await _mediator.Send(new ListQuery());
+        return await _mediator.Send(new ListQuery(), cancellationToken);
     }
 }
 

--- a/DynamoLeagueBlazor/Server/Features/Fines/ManageFine.cs
+++ b/DynamoLeagueBlazor/Server/Features/Fines/ManageFine.cs
@@ -24,11 +24,11 @@ public class ManageFineController : ControllerBase
     }
 
     [HttpPost]
-    public async Task<IActionResult> PostAsync([FromBody] ManageFineRequest request)
+    public async Task<IActionResult> PostAsync([FromBody] ManageFineRequest request, CancellationToken cancellationToken)
     {
         var query = _mapper.Map<ManageFineQuery>(request);
 
-        await _mediator.Send(query);
+        await _mediator.Send(query, cancellationToken);
 
         return NoContent();
     }

--- a/DynamoLeagueBlazor/Server/Features/FreeAgents/AddBid.cs
+++ b/DynamoLeagueBlazor/Server/Features/FreeAgents/AddBid.cs
@@ -1,7 +1,6 @@
 ﻿using AutoMapper;
 using DynamoLeagueBlazor.Server.Infrastructure;
 using DynamoLeagueBlazor.Server.Infrastructure.Identity;
-using DynamoLeagueBlazor.Server.Models;
 using DynamoLeagueBlazor.Shared.Features.FreeAgents;
 using FluentValidation;
 using MediatR;
@@ -18,19 +17,29 @@ public class AddBidController : ControllerBase
 {
     private readonly IMediator _mediator;
     private readonly IMapper _mapper;
+    private readonly IBidAmountValidator _bidAmountValidator;
 
-    public AddBidController(IMediator mediator, IMapper mapper)
+    public AddBidController(IMediator mediator, IMapper mapper, IBidAmountValidator bidAmountValidator)
     {
         _mediator = mediator;
         _mapper = mapper;
+        _bidAmountValidator = bidAmountValidator;
+    }
+
+    [HttpGet]
+    public async Task<bool> GetAsync([FromQuery] int playerId, int amount, CancellationToken cancellationToken)
+    {
+        var isValidBid = await _bidAmountValidator.IsHighestBidAsync(new AddBidRequest { Amount = amount, PlayerId = playerId }, cancellationToken);
+
+        return isValidBid;
     }
 
     [HttpPost]
-    public async Task<int> PostAsync([FromBody] AddBidRequest request)
+    public async Task<int> PostAsync([FromBody] AddBidRequest request, CancellationToken cancellationToken)
     {
         var query = _mapper.Map<AddBidQuery>(request);
 
-        return await _mediator.Send(query);
+        return await _mediator.Send(query, cancellationToken);
     }
 }
 
@@ -70,18 +79,22 @@ public class AddBidMappingProfile : Profile
     }
 }
 
-public class AddBidRequestValidator : AbstractValidator<AddBidRequest>
+public class BidAmountValidator : IBidAmountValidator
 {
-    public AddBidRequestValidator(ApplicationDbContext dbContext)
-    {
-        RuleFor(x => x.Amount).MustAsync(async (request, value, context, cancellationToken) =>
-        {
-            var player = await dbContext.Players
-                .Where(p => p.Id == request.PlayerId
-                    && p.Bids.GetHighestBidder().Amount > value)
-                .SingleOrDefaultAsync(cancellationToken);
+    private readonly ApplicationDbContext _dbContext;
 
-            return player != null;
-        });
+    public BidAmountValidator(ApplicationDbContext dbContext)
+    {
+        this._dbContext = dbContext;
+    }
+
+    public async Task<bool> IsHighestBidAsync(AddBidRequest request, CancellationToken cancellationToken)
+    {
+        var noHigherBidWasFound = await _dbContext.Players
+            .Where(p => p.Id == request.PlayerId
+                && p.Bids.All(b => request.Amount > b.Amount))
+            .AnyAsync(cancellationToken);
+
+        return noHigherBidWasFound;
     }
 }

--- a/DynamoLeagueBlazor/Server/Features/FreeAgents/AddBid.cs
+++ b/DynamoLeagueBlazor/Server/Features/FreeAgents/AddBid.cs
@@ -90,11 +90,11 @@ public class BidAmountValidator : IBidAmountValidator
 
     public async Task<bool> IsHighestBidAsync(AddBidRequest request, CancellationToken cancellationToken)
     {
-        var noHigherBidWasFound = await _dbContext.Players
+        var isHighestBid = await _dbContext.Players
             .Where(p => p.Id == request.PlayerId
                 && p.Bids.All(b => request.Amount > b.Amount))
             .AnyAsync(cancellationToken);
 
-        return noHigherBidWasFound;
+        return isHighestBid;
     }
 }

--- a/DynamoLeagueBlazor/Server/Features/FreeAgents/Detail.cs
+++ b/DynamoLeagueBlazor/Server/Features/FreeAgents/Detail.cs
@@ -24,9 +24,9 @@ public class DetailController : ControllerBase
     }
 
     [HttpGet("{PlayerId}")]
-    public async Task<FreeAgentDetailResult> GetAsync([FromRoute] DetailQuery query)
+    public async Task<FreeAgentDetailResult> GetAsync([FromRoute] DetailQuery query, CancellationToken cancellationToken)
     {
-        return await _mediator.Send(query);
+        return await _mediator.Send(query, cancellationToken);
     }
 }
 
@@ -46,7 +46,7 @@ public class DetailHandler : IRequestHandler<DetailQuery, FreeAgentDetailResult>
     public async Task<FreeAgentDetailResult> Handle(DetailQuery request, CancellationToken cancellationToken)
     {
         var result = await _dbContext.Players
-            .Include(p => p.Bids.OrderByDescending(b => b.DateTime))
+            .Include(p => p.Bids)
                 .ThenInclude(b => b.Team)
             .Where(p => p.Id == request.PlayerId)
             .ProjectTo<FreeAgentDetailResult>(_mapper.ConfigurationProvider)
@@ -71,7 +71,8 @@ public class DetailMappingProfile : Profile
     {
         CreateMap<Player, FreeAgentDetailResult>()
             .ForMember(d => d.EndOfFreeAgency, mo => mo.MapFrom(s => s.EndOfFreeAgency!.Value.ToShortDateString()))
-            .ForMember(d => d.Team, mo => mo.MapFrom(s => s.Team.TeamName));
+            .ForMember(d => d.Team, mo => mo.MapFrom(s => s.Team.TeamName))
+            .ForMember(d => d.Bids, mo => mo.MapFrom(s => s.Bids.OrderByDescending(b => b.DateTime)));
         CreateMap<Bid, FreeAgentDetailResult.BidItem>()
             .ForMember(d => d.Team, mo => mo.MapFrom(s => s.Team.TeamName))
             .ForMember(d => d.Amount, mo => mo.MapFrom(s => s.Amount.ToString("C0")))

--- a/DynamoLeagueBlazor/Server/Features/FreeAgents/List.cs
+++ b/DynamoLeagueBlazor/Server/Features/FreeAgents/List.cs
@@ -24,9 +24,9 @@ public class ListController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<FreeAgentListResult> GetAsync()
+    public async Task<FreeAgentListResult> GetAsync(CancellationToken cancellationToken)
     {
-        return await _mediator.Send(new ListQuery());
+        return await _mediator.Send(new ListQuery(), cancellationToken);
     }
 }
 

--- a/DynamoLeagueBlazor/Server/Features/Players/AddFine.cs
+++ b/DynamoLeagueBlazor/Server/Features/Players/AddFine.cs
@@ -24,11 +24,11 @@ public class AddFineController : ControllerBase
     }
 
     [HttpPost]
-    public async Task<int> PostAsync([FromBody] AddFineRequest request)
+    public async Task<int> PostAsync([FromBody] AddFineRequest request, CancellationToken cancellationToken)
     {
         var query = _mapper.Map<AddFineQuery>(request);
 
-        return await _mediator.Send(query);
+        return await _mediator.Send(query, cancellationToken);
     }
 }
 

--- a/DynamoLeagueBlazor/Server/Features/Players/FineDetail.cs
+++ b/DynamoLeagueBlazor/Server/Features/Players/FineDetail.cs
@@ -20,9 +20,9 @@ public class FineDetailController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<FineDetailResult> GetAsync([FromQuery] FineDetailRequest request)
+    public async Task<FineDetailResult> GetAsync([FromQuery] FineDetailRequest request, CancellationToken cancellationToken)
     {
-        return await _mediator.Send(new FineDetailQuery(request.PlayerId));
+        return await _mediator.Send(new FineDetailQuery(request.PlayerId), cancellationToken);
     }
 }
 

--- a/DynamoLeagueBlazor/Server/Features/Players/List.cs
+++ b/DynamoLeagueBlazor/Server/Features/Players/List.cs
@@ -23,9 +23,9 @@ public class ListController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<PlayerListResult> GetAsync()
+    public async Task<PlayerListResult> GetAsync(CancellationToken cancellationToken)
     {
-        return await _mediator.Send(new ListQuery());
+        return await _mediator.Send(new ListQuery(), cancellationToken);
     }
 }
 

--- a/DynamoLeagueBlazor/Server/Features/Teams/Detail.cs
+++ b/DynamoLeagueBlazor/Server/Features/Teams/Detail.cs
@@ -25,9 +25,9 @@ public class DetailController : ControllerBase
     }
 
     [HttpGet("{teamId}")]
-    public async Task<TeamDetailResult> GetAsync(int teamId)
+    public async Task<TeamDetailResult> GetAsync(int teamId, CancellationToken cancellationToken)
     {
-        return await _mediator.Send(new DetailQuery(teamId));
+        return await _mediator.Send(new DetailQuery(teamId), cancellationToken);
     }
 }
 

--- a/DynamoLeagueBlazor/Server/Features/Teams/List.cs
+++ b/DynamoLeagueBlazor/Server/Features/Teams/List.cs
@@ -25,9 +25,9 @@ public class ListController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<TeamListResult> GetAsync()
+    public async Task<TeamListResult> GetAsync(CancellationToken cancellationToken)
     {
-        return await _mediator.Send(new ListQuery());
+        return await _mediator.Send(new ListQuery(), cancellationToken);
     }
 }
 

--- a/DynamoLeagueBlazor/Server/Program.cs
+++ b/DynamoLeagueBlazor/Server/Program.cs
@@ -3,6 +3,7 @@ using DynamoLeagueBlazor.Server.Areas.Identity;
 using DynamoLeagueBlazor.Server.Features.Fines;
 using DynamoLeagueBlazor.Server.Infrastructure;
 using DynamoLeagueBlazor.Server.Infrastructure.Identity;
+using DynamoLeagueBlazor.Shared.Features.FreeAgents;
 using DynamoLeagueBlazor.Shared.Features.Players;
 using FluentValidation.AspNetCore;
 using MediatR;
@@ -62,9 +63,10 @@ try
     builder.Services.AddMediatR(Assembly.GetExecutingAssembly());
     builder.Services.AddFluentValidation(fv =>
     {
-        fv.RegisterValidatorsFromAssemblyContaining<AddBidRequestValidator>();
         fv.RegisterValidatorsFromAssemblyContaining<AddFineRequestValidator>();
     });
+
+    builder.Services.AddTransient<IBidAmountValidator, BidAmountValidator>();
 
     builder.Services.Configure<EmailSettings>(builder.Configuration.GetSection(EmailSettings.Email))
         .AddSingleton(s => s.GetRequiredService<IOptions<EmailSettings>>().Value);

--- a/DynamoLeagueBlazor/Shared/DynamoLeagueBlazor.Shared.csproj
+++ b/DynamoLeagueBlazor/Shared/DynamoLeagueBlazor.Shared.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.SmartEnum" Version="2.0.1" />
-    <PackageReference Include="FluentValidation" Version="10.3.5" />
+    <PackageReference Include="FluentValidation" Version="10.3.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoLeagueBlazor/Shared/Features/AsyncAbstractValidator.cs
+++ b/DynamoLeagueBlazor/Shared/Features/AsyncAbstractValidator.cs
@@ -1,0 +1,30 @@
+﻿using FluentValidation;
+using FluentValidation.Results;
+
+namespace DynamoLeagueBlazor.Shared.Helpers;
+
+/// <summary>
+///     A total hack used for asynchronous validation with Blazor applications because of the lack of first-class support with EditForm.
+///     See <see href="https://github.com/Blazored/FluentValidation/issues/38"/> for one example of this - but is present on all FluentValidation + Blazor libraries.
+///     <para>
+///         TODO: Revisit this periodically. Hopefully .NET 7?
+///     </para>
+/// </summary>
+public abstract class AsyncAbstractValidator<T> : AbstractValidator<T>
+{
+    private Task<ValidationResult> _validateTask;
+
+    public override Task<ValidationResult> ValidateAsync(ValidationContext<T> context, CancellationToken cancellation = default)
+        => _validateTask = base.ValidateAsync(context, cancellation);
+
+    public override ValidationResult Validate(ValidationContext<T> context)
+    {
+        var result = base.Validate(context);
+        _validateTask = Task.FromResult(result);
+        return result;
+    }
+
+    public Task<ValidationResult> WaitForValidateAsync()
+         => _validateTask ?? Task.FromResult<ValidationResult>(null);
+
+}

--- a/DynamoLeagueBlazor/Shared/Features/FreeAgents/AddBid.cs
+++ b/DynamoLeagueBlazor/Shared/Features/FreeAgents/AddBid.cs
@@ -1,0 +1,28 @@
+﻿using DynamoLeagueBlazor.Shared.Helpers;
+using FluentValidation;
+
+namespace DynamoLeagueBlazor.Shared.Features.FreeAgents;
+
+public class AddBidRequest
+{
+    public int PlayerId { get; set; }
+    public int Amount { get; set; }
+}
+
+public class AddBidRequestValidator : AsyncAbstractValidator<AddBidRequest>
+{
+    public AddBidRequestValidator(IBidAmountValidator bidAmountValidator)
+    {
+        RuleFor(x => x.PlayerId).GreaterThan(0);
+        RuleFor(x => x.Amount)
+            .Cascade(CascadeMode.Stop)
+            .GreaterThan(0)
+            .MustAsync((request, value, context, token) => bidAmountValidator.IsHighestBidAsync(request, token))
+            .WithMessage("Please enter a bid higher than the current amount.");
+    }
+}
+
+public interface IBidAmountValidator
+{
+    public Task<bool> IsHighestBidAsync(AddBidRequest request, CancellationToken cancellationToken);
+}

--- a/DynamoLeagueBlazor/Shared/Features/FreeAgents/Detail.cs
+++ b/DynamoLeagueBlazor/Shared/Features/FreeAgents/Detail.cs
@@ -1,6 +1,4 @@
-﻿using FluentValidation;
-
-namespace DynamoLeagueBlazor.Shared.Features.FreeAgents;
+﻿namespace DynamoLeagueBlazor.Shared.Features.FreeAgents;
 
 public class FreeAgentDetailResult
 {
@@ -17,20 +15,5 @@ public class FreeAgentDetailResult
         public string Team { get; set; }
         public string Amount { get; set; }
         public string Date { get; set; }
-    }
-}
-
-public class AddBidRequest
-{
-    public int PlayerId { get; set; }
-    public int Amount { get; set; }
-}
-
-public class AddBidRequestValidator : AbstractValidator<AddBidRequest>
-{
-    public AddBidRequestValidator()
-    {
-        RuleFor(x => x.PlayerId).GreaterThan(0);
-        RuleFor(x => x.Amount).GreaterThan(0);
     }
 }

--- a/DynamoLeagueBlazor/Tests/Features/Fines/ManageFineTests.cs
+++ b/DynamoLeagueBlazor/Tests/Features/Fines/ManageFineTests.cs
@@ -1,9 +1,7 @@
 ﻿using AutoBogus;
 using DynamoLeagueBlazor.Server.Models;
 using DynamoLeagueBlazor.Shared.Features.Fines;
-using Microsoft.AspNetCore.Mvc;
 using System.Net.Http.Json;
-using System.Text.Json;
 
 namespace DynamoLeagueBlazor.Tests.Features.Fines;
 
@@ -90,21 +88,5 @@ internal class ManageFineTests : IntegrationTestBase
 
         var fine = await application.FirstOrDefaultAsync<Fine>();
         fine.Should().BeNull();
-    }
-
-    [Test]
-    public async Task GivenAuthenticatedAdmin_WhenAnInvalidFine_ThenReturnsBadRequestWithErrors()
-    {
-        var application = CreateAdminAuthenticatedApplication();
-
-        var client = application.CreateClient();
-
-        var badRequest = new ManageFineRequest { FineId = -1 };
-        var response = await client.PostAsJsonAsync(_endpoint, badRequest);
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        var details = await JsonSerializer.DeserializeAsync<ValidationProblemDetails>(await response.Content.ReadAsStreamAsync());
-        details.Should().NotBeNull();
-        details!.Errors.Should().NotBeEmpty();
     }
 }

--- a/DynamoLeagueBlazor/Tests/Features/FreeAgents/AddBidTests.cs
+++ b/DynamoLeagueBlazor/Tests/Features/FreeAgents/AddBidTests.cs
@@ -101,6 +101,6 @@ internal class AddBidTests : IntegrationTestBase
         bid!.Amount.Should().Be(request.Amount);
         bid.PlayerId.Should().Be(request.PlayerId);
         bid.TeamId.Should().Be(UserAuthenticationHandler.TeamId);
-        bid.DateTime.Should().BeCloseTo(DateTime.Now, TimeSpan.FromSeconds(5));
+        bid.CreatedOn.Should().BeCloseTo(DateTime.Now, TimeSpan.FromSeconds(5));
     }
 }

--- a/DynamoLeagueBlazor/Tests/Features/FreeAgents/AddBidTests.cs
+++ b/DynamoLeagueBlazor/Tests/Features/FreeAgents/AddBidTests.cs
@@ -1,0 +1,106 @@
+﻿using AutoBogus;
+using DynamoLeagueBlazor.Client.Features.FreeAgents;
+using DynamoLeagueBlazor.Server.Models;
+using DynamoLeagueBlazor.Shared.Features.FreeAgents;
+using System.Net.Http.Json;
+
+namespace DynamoLeagueBlazor.Tests.Features.FreeAgents;
+
+internal class AddBidTests : IntegrationTestBase
+{
+    private static AddBidRequest CreateFakeValidRequest()
+    {
+        var faker = new AutoFaker<AddBidRequest>()
+            .RuleFor(f => f.Amount, (faker) => faker.Random.Int(min: 1));
+
+        return faker.Generate();
+    }
+
+    [Test]
+    public async Task GET_GivenUnauthenticatedUser_ThenDoesNotAllowAccess()
+    {
+        var application = CreateUnauthenticatedApplication();
+        var client = application.CreateClient();
+        var endpoint = AddBidRouteFactory.CreateRequestUri(CreateFakeValidRequest());
+
+        var response = await client.GetAsync(endpoint);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task GET_GivenAnyAuthenticatedUser_WhenIsHighestBid_ThenReturnsTrue()
+    {
+        var application = CreateUserAuthenticatedApplication();
+        var client = application.CreateClient();
+
+        var mockPlayer = CreateFakePlayer();
+        await application.AddAsync(mockPlayer);
+        var request = CreateFakeValidRequest();
+        request.PlayerId = mockPlayer.Id;
+        var endpoint = AddBidRouteFactory.CreateRequestUri(request);
+
+        var result = await client.GetFromJsonAsync<bool>(endpoint);
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task GET_GivenAnyAuthenticatedUser_WhenIsNotHighestBid_ThenReturnsFalse()
+    {
+        var application = CreateUserAuthenticatedApplication();
+        var client = application.CreateClient();
+
+        var mockTeam = CreateFakeTeam();
+        await application.AddAsync(mockTeam);
+        var mockPlayer = CreateFakePlayer();
+        await application.AddAsync(mockPlayer);
+        var request = CreateFakeValidRequest();
+        request.PlayerId = mockPlayer.Id;
+        request.Amount = int.MinValue;
+        var endpoint = AddBidRouteFactory.CreateRequestUri(request);
+        mockPlayer.AddBid(int.MaxValue, mockTeam.Id);
+        await application.UpdateAsync(mockPlayer);
+
+        var result = await client.GetFromJsonAsync<bool>(endpoint);
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task POST_GivenUnauthenticatedUser_ThenDoesNotAllowAccess()
+    {
+        var application = CreateUnauthenticatedApplication();
+        var client = application.CreateClient();
+
+        var endpoint = AddBidRouteFactory.CreateRequestUri(CreateFakeValidRequest());
+
+        var response = await client.GetAsync(endpoint);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task POST_GivenAnyAuthenticatedUser_WhenIsHighestBid_ThenSavesTheBid()
+    {
+        var application = CreateUserAuthenticatedApplication();
+        var client = application.CreateClient();
+
+        var mockTeam = CreateFakeTeam();
+        await application.AddAsync(mockTeam);
+        var mockPlayer = CreateFakePlayer();
+        await application.AddAsync(mockPlayer);
+        var request = CreateFakeValidRequest();
+        request.PlayerId = mockPlayer.Id;
+        var endpoint = AddBidRouteFactory.CreateRequestUri(request);
+
+        var result = await client.PostAsJsonAsync(endpoint, request);
+
+        result.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var bid = await application.FirstOrDefaultAsync<Bid>();
+        bid.Should().NotBeNull();
+        bid!.Amount.Should().Be(request.Amount);
+        bid.PlayerId.Should().Be(request.PlayerId);
+        bid.TeamId.Should().Be(UserAuthenticationHandler.TeamId);
+        bid.DateTime.Should().BeCloseTo(DateTime.Now, TimeSpan.FromSeconds(5));
+    }
+}

--- a/DynamoLeagueBlazor/Tests/Features/FreeAgents/ListTests.cs
+++ b/DynamoLeagueBlazor/Tests/Features/FreeAgents/ListTests.cs
@@ -66,5 +66,6 @@ internal class ListTests : IntegrationTestBase
         freeAgent.PlayerHeadShotUrl.Should().Be(mockPlayer.HeadShot);
         freeAgent.HighestBid.Should().Be(bidAmount.ToString("C0"));
         freeAgent.BiddingEnds.Should().Be(biddingEnds.ToShortDateString());
+        freeAgent.CurrentUserIsHighestBidder.Should().BeTrue();
     }
 }

--- a/DynamoLeagueBlazor/Tests/Features/Players/AddFineTests.cs
+++ b/DynamoLeagueBlazor/Tests/Features/Players/AddFineTests.cs
@@ -2,9 +2,7 @@
 using DynamoLeagueBlazor.Server.Models;
 using DynamoLeagueBlazor.Shared.Features.Players;
 using DynamoLeagueBlazor.Shared.Utilities;
-using Microsoft.AspNetCore.Mvc;
 using System.Net.Http.Json;
-using System.Text.Json;
 
 namespace DynamoLeagueBlazor.Tests.Features.Fines;
 
@@ -53,21 +51,5 @@ internal class AddFineTests : IntegrationTestBase
         fine.Status.Should().BeFalse();
         fine.FineReason.Should().Be(stubRequest.FineReason);
         fine.FineAmount.Should().Be(FineUtilities.CalculateFineAmount(mockPlayer.ContractValue));
-    }
-
-    [Test]
-    public async Task GivenAnyAuthenticatedUser_WhenAnInvalidFine_ThenReturnsBadRequestWithErrors()
-    {
-        var application = CreateUserAuthenticatedApplication();
-
-        var client = application.CreateClient();
-
-        var badRequest = new AddFineRequest { PlayerId = -1, FineReason = string.Empty };
-        var response = await client.PostAsJsonAsync(_endpoint, badRequest);
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        var details = await JsonSerializer.DeserializeAsync<ValidationProblemDetails>(await response.Content.ReadAsStreamAsync());
-        details.Should().NotBeNull();
-        details!.Errors.Should().NotBeEmpty();
     }
 }

--- a/DynamoLeagueBlazor/Tests/IntegrationTesting.cs
+++ b/DynamoLeagueBlazor/Tests/IntegrationTesting.cs
@@ -184,16 +184,24 @@ internal class UserAuthenticationHandler : AuthenticationHandler<AuthenticationS
 internal class AdminAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
 {
     public const string AuthenticationName = RoleName.Admin;
-    public const int TeamId = 1;
+    public static int TeamId = 1;
+    private readonly ApplicationDbContext _applicationDbContext;
 
-    public AdminAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options,
-        ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
+    public AdminAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        ISystemClock clock,
+        ApplicationDbContext applicationDbContext)
         : base(options, logger, encoder, clock)
     {
+        _applicationDbContext = applicationDbContext;
     }
 
-    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
+        TeamId = (await _applicationDbContext.Teams.FirstOrDefaultAsync())?.Id ?? TeamId;
+
         var claims = new[] {
             new Claim(ClaimTypes.Name, RandomString),
             new Claim(ClaimTypes.Role, RoleName.Admin),
@@ -205,6 +213,6 @@ internal class AdminAuthenticationHandler : AuthenticationHandler<Authentication
 
         var result = AuthenticateResult.Success(ticket);
 
-        return Task.FromResult(result);
+        return result;
     }
 }

--- a/DynamoLeagueBlazor/Tests/IntegrationTesting.cs
+++ b/DynamoLeagueBlazor/Tests/IntegrationTesting.cs
@@ -148,16 +148,24 @@ internal static class IntegrationTestExtensions
 internal class UserAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
 {
     public const string AuthenticationName = RoleName.User;
-    public const int TeamId = 1;
+    public static int TeamId = 1;
+    private readonly ApplicationDbContext _applicationDbContext;
 
-    public UserAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options,
-        ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
+    public UserAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        ISystemClock clock,
+        ApplicationDbContext applicationDbContext)
         : base(options, logger, encoder, clock)
     {
+        _applicationDbContext = applicationDbContext;
     }
 
-    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
+        TeamId = (await _applicationDbContext.Teams.FirstOrDefaultAsync())?.Id ?? TeamId;
+
         var claims = new[] {
             new Claim(ClaimTypes.Name, RandomString),
             new Claim(ClaimTypes.Role, RoleName.User),
@@ -169,7 +177,7 @@ internal class UserAuthenticationHandler : AuthenticationHandler<AuthenticationS
 
         var result = AuthenticateResult.Success(ticket);
 
-        return Task.FromResult(result);
+        return result;
     }
 }
 


### PR DESCRIPTION
- Added IBidAmountValidator with implementations both server & client side.

- Added async abstract validator because Blazor's EditForm doesn't have an async validator and I don't like MudBlazors form implementation (it's way too wordy!).
  - The async validators must be explictly set inside of the Blazor `EditForm` `FluentValidator` component, but still will get registered server-side automatically because of `AbstractValidator` inheritance.

- Removed a few tests dealing with returning `ValidationProblemDetails` which upon re-review seemed to be really testing internal ASP.NET behavior.

- Added `CancellationToken`s where appropriate.

- Added the ability for integration tests to set the first team created to the authenticated user/admin for cases where we need to assert against that user/admin's team id.

Closing #9 