### PR TITLE
[Fix] Registering new users is redirecting back to login

### DIFF
--- a/DynamoLeagueBlazor/Server/Program.cs
+++ b/DynamoLeagueBlazor/Server/Program.cs
@@ -114,7 +114,7 @@ try
     app.UseSerilogIngestion();
     app.UseSerilogRequestLogging();
 
-    app.MapRazorPages().RequireAuthorization();
+    app.MapRazorPages();
     app.MapControllers().RequireAuthorization();
     app.MapFallbackToFile("index.html");
 


### PR DESCRIPTION
Resolves #71

I have removed the `.RequiresAuthorization` from the `Program.cs` file within the Server project. I checked to see if I could access the page and sign up and all seemed to be working.