### PR TITLE
Reduce the spacing in the RankedList razor component

### DIFF
--- a/src/Client/Features/Dashboard/Shared/RankedList.razor
+++ b/src/Client/Features/Dashboard/Shared/RankedList.razor
@@ -12,7 +12,7 @@
     </MudItem>
     @foreach(var rankedItem in RankedItems.Skip(3))
     {
-        <MudItem xs=12 sm=6>
+        <MudItem xs=12 sm=6 Class="pa-0">
             <RankedCard RankedItem="@rankedItem" NameTypo=Typo.body1 AmountTypo=Typo.h6 />
         </MudItem>
     }

--- a/src/Client/Features/Dashboard/Shared/RankedList.razor
+++ b/src/Client/Features/Dashboard/Shared/RankedList.razor
@@ -12,7 +12,7 @@
     </MudItem>
     @foreach(var rankedItem in RankedItems.Skip(3))
     {
-        <MudItem xs=12 sm=6 Class="pa-0">
+        <MudItem xs=12 sm=6 Class="pt-0 pb-0">
             <RankedCard RankedItem="@rankedItem" NameTypo=Typo.body1 AmountTypo=Typo.h6 />
         </MudItem>
     }

--- a/src/Client/Features/Dashboard/TopOffenders.razor
+++ b/src/Client/Features/Dashboard/TopOffenders.razor
@@ -22,7 +22,7 @@
 }
 else
 {
-    <MudGrid>
+    <MudGrid Class="justify-center">
         <MudItem xs=12>
             <PageHeader>
                 Top Offenders

--- a/src/Client/Features/Dashboard/TopTeamFines.razor
+++ b/src/Client/Features/Dashboard/TopTeamFines.razor
@@ -22,7 +22,7 @@
 }
 else
 {
-    <MudGrid>
+    <MudGrid Class="justify-center">
         <MudItem xs=12>
             <PageHeader>
                 Top Team Fines


### PR DESCRIPTION
This PR reduces the spacing in the Ranked List component. As both places use this one component adding this spacing to the one component does both.

![Spacing](https://user-images.githubusercontent.com/10053087/203843674-a7e60245-64fe-40ee-a079-57934314c210.png)

Relates to: #178

EDIT: This now deals with the centered item at the bottom